### PR TITLE
Fine tune cache headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,13 @@
 [build]
   command = "pip install fonttools brotli zopfli && yarn build"
   publish = "build"
+
+[[headers]]
+  for = "/subfont/*"
+  [headers.values]
+    Cache-Control = "max-age=31536000"
+
+[[headers]]
+  for = "/optimized_images/*"
+  [headers.values]
+    Cache-Control = "max-age=31536000"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "NODE_ENV=production snowpack build",
     "postbuild": "yarn optimize-fonts",
     "clean": "rm -rf build _output _cache",
-    "optimize-fonts": "subfont build --in-place --harfbuzz --no-fallbacks --font-display block --recursive --subset-per-page",
+    "optimize-fonts": "subfont build --in-place --harfbuzz --no-fallbacks --font-display block --recursive",
     "format": "prettier --write \"src/**/*.js\" *.js \"src/**/*.css\"",
     "lint": "prettier --check \"src/**/*.js\" *.js \"src/**/*.css\""
   },

--- a/utils/image.js
+++ b/utils/image.js
@@ -5,8 +5,8 @@ const hash = require("./hash");
 
 const CACHE = {};
 const IMAGES_ROOT = "./static/";
-const OUTPUT_PATH = "./_output/images/";
-const URL_PATH = "/images/";
+const OUTPUT_PATH = "./_output/optimized_images/";
+const URL_PATH = "/optimized_images/";
 
 // DO NOT IDENT THIS PLEASE OTHERWHISE IT WILL BREAK
 // A LIMTATION FROM MARKDOWN-IT


### PR DESCRIPTION
Change image optimization strategy so the files are outputted to a different folder.

Then we just cache it.
We only cache `subfont` and `optimized_imgaes` dirs because they are the only ones that are hashed.
If we hash the rest of the assets, I'll add them there.

The rest of the files are not that important, as they are very small <2kb, and Netlify also caches them, albeit in a different way. Netlify forces all assets to be revalidated, so you make a server request and if Netlify notices that the requested file changed since the last time the client asked for it, we serve it. Hashing is not done by either Eleventy or Snowpack, so we need to roll out our own stuff.

Also the important assets to **NOT** cache with the Netlify way are Fonts (to avoid layout shifts) and Images for the same reason.