### PR TITLE
Reinstate @11ty/eleventy-img

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,7 +8,6 @@ const markdownItRenderer = new markdownIt({ html: true }).use(
   mdImplicitFigures,
 );
 const image = require("./utils/image");
-const Image = require("@11ty/eleventy-img");
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.setTemplateFormats(["html", "liquid", "njk", "md"]);
@@ -51,26 +50,8 @@ module.exports = function (eleventyConfig) {
     image(src, alt, klass, false),
   );
 
-  eleventyConfig.addShortcode(
-    "responsiveImage",
-    async (src, alt, klass = "") => {
-      const metadata = await Image(`./static/${src}`, {
-        widths: [300, 600],
-        formats: ["avif", "jpeg"],
-        outputDir: "_output/optimized_images",
-        urlPath: "/optimized_images",
-        widths: [320, 480, 800, 1024, 1280],
-      });
-
-      const imageAttributes = {
-        alt,
-        class: klass,
-        loading: "lazy",
-        decoding: "async",
-      };
-
-      return Image.generateHTML(metadata, imageAttributes);
-    },
+  eleventyConfig.addShortcode("responsiveImage", async (src, alt, klass = "") =>
+    image(src, alt, klass, true),
   );
 
   eleventyConfig.addTransform("htmlmin", function (content, outputPath) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,6 +8,7 @@ const markdownItRenderer = new markdownIt({ html: true }).use(
   mdImplicitFigures,
 );
 const image = require("./utils/image");
+const Image = require("@11ty/eleventy-img");
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.setTemplateFormats(["html", "liquid", "njk", "md"]);
@@ -50,8 +51,26 @@ module.exports = function (eleventyConfig) {
     image(src, alt, klass, false),
   );
 
-  eleventyConfig.addShortcode("responsiveImage", async (src, alt, klass = "") =>
-    image(src, alt, klass, true),
+  eleventyConfig.addShortcode(
+    "responsiveImage",
+    async (src, alt, klass = "") => {
+      const metadata = await Image(`./static/${src}`, {
+        widths: [300, 600],
+        formats: ["avif", "jpeg"],
+        outputDir: "_output/optimized_images",
+        urlPath: "/optimized_images",
+        widths: [320, 480, 800, 1024, 1280],
+      });
+
+      const imageAttributes = {
+        alt,
+        class: klass,
+        loading: "lazy",
+        decoding: "async",
+      };
+
+      return Image.generateHTML(metadata, imageAttributes);
+    },
   );
 
   eleventyConfig.addTransform("htmlmin", function (content, outputPath) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "prettier --check \"src/**/*.js\" *.js \"src/**/*.css\""
   },
   "dependencies": {
+    "@11ty/eleventy-img": "^0.7.3",
     "@11ty/eleventy-plugin-rss": "^1.0.9",
     "instant.page": "^5.1.0",
     "vanilla-lazyload": "^17.3.0"

--- a/utils/image.js
+++ b/utils/image.js
@@ -1,9 +1,8 @@
 const sharp = require("sharp");
 const fs = require("fs");
 const path = require("path");
-const hash = require("./hash");
+const Image = require("@11ty/eleventy-img");
 
-const CACHE = {};
 const IMAGES_ROOT = "./static/";
 const OUTPUT_PATH = "./_output/optimized_images/";
 const URL_PATH = "/optimized_images/";
@@ -22,72 +21,6 @@ class="${klass}">
 </picture>`;
 }
 
-async function saveSharpImage(sharpImage, fileName) {
-  if (fs.existsSync(fileName)) return;
-
-  await sharpImage.toFile(fileName);
-}
-
-async function generateImage(sharpImage, fileName, width = null) {
-  sharpImage.resize({
-    width: width ? width : defaultImgWidth,
-  });
-
-  if (!fs.existsSync(OUTPUT_PATH))
-    fs.mkdirSync(OUTPUT_PATH, { recursive: true });
-
-  await Promise.all([
-    saveSharpImage(sharpImage, path.join(OUTPUT_PATH, `${fileName}.avif`)),
-    saveSharpImage(sharpImage, path.join(OUTPUT_PATH, `${fileName}.jpeg`)),
-  ]);
-}
-
-async function generateImages(inputPath, imageHash, responsive) {
-  const sharpImage = await sharp(inputPath);
-  const imageWidth = (await sharpImage.metadata()).width;
-  const defaultImgWidth = imageWidth > 1280 ? 1280 : imageWidth;
-  const widths = responsive ? [320, 480, 800, 1024, 1280] : [defaultImgWidth];
-
-  await Promise.all(
-    widths.map((width) =>
-      generateImage(sharpImage, `${imageHash}-${width}`, width),
-    ),
-  );
-
-  const placeholder = await sharp(inputPath)
-    .resize({ width: 64 })
-    .blur()
-    .toBuffer();
-
-  return {
-    jpeg: {
-      url: path.join(URL_PATH, `${imageHash}.jpeg`),
-      srcset: widths
-        .map(
-          (width) =>
-            `${path.join(URL_PATH, `${imageHash}-${width}.jpeg`)} ${width}w`,
-        )
-        .join(", "),
-      sizes: widths
-        .map((width) => `(max-width: ${width}px) ${width - 20}px`)
-        .join(", "),
-    },
-    avif: {
-      url: path.join(URL_PATH, `${imageHash}.avif`),
-      srcset: widths
-        .map(
-          (width) =>
-            `${path.join(URL_PATH, `${imageHash}-${width}.avif`)} ${width}w`,
-        )
-        .join(", "),
-      sizes: widths
-        .map((width) => `(max-width: ${width}px) ${width}px`)
-        .join(", "),
-    },
-    placeholder: `data:image/png;base64,${placeholder.toString("base64")}`,
-  };
-}
-
 module.exports = async (src, alt, klass, responsive = false) => {
   try {
     if (!alt) throw new Error(`Missing \`alt\` from: ${src}`);
@@ -97,40 +30,21 @@ module.exports = async (src, alt, klass, responsive = false) => {
     if (process.env.NODE_ENV !== "production")
       return skipOptimization(src, alt, klass);
 
-    const inputPath = path.join(IMAGES_ROOT, src);
-    const imageHash = (await hash(inputPath)).slice(0, 20);
-    let imageStats = CACHE[imageHash];
+    const metadata = await Image(path.join(IMAGES_ROOT, src), {
+      formats: ["avif", "jpeg"],
+      outputDir: OUTPUT_PATH,
+      urlPath: URL_PATH,
+      widths: responsive ? [320, 480, 800, 1024, 1280] : [null],
+    });
 
-    if (!imageStats) {
-      imageStats = await generateImages(inputPath, imageHash, responsive);
-      CACHE[hash] = imageStats;
-    }
+    const imageAttributes = {
+      alt,
+      class: klass,
+      loading: "lazy",
+      decoding: "async",
+    };
 
-    return `
-<picture>
-<source type="image/avif" data-srcset="${imageStats.avif.srcset}" data-sizes="${imageStats.avif.sizes}">
-<img
-alt="${alt}"
-src="${imageStats.placeholder}"
-data-src="${imageStats.jpeg.url}"
-data-srcset="${imageStats.jpeg.srcset}"
-data-sizes="${imageStats.jpeg.sizes}"
-class="lazy ${klass}">
-</picture>
-
-<noscript>
-<picture>
-<source type="image/avif" srcset="${imageStats.avif.srcset}" sizes="${imageStats.avif.sizes}">
-<img
-loading="lazy"
-alt="${alt}"
-src="${imageStats.jpeg.url}"
-srcset="${imageStats.jpeg.srcset}"
-sizes="${imageStats.jpeg.sizes}"
-class="${klass}">
-</picture>
-</noscript>
-  `;
+    return Image.generateHTML(metadata, imageAttributes);
   } catch (error) {
     console.error(`Error on ${src}`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,30 @@
   resolved "https://registry.yarnpkg.com/@11ty/dependency-tree/-/dependency-tree-1.0.0.tgz#b1fa53da49aafe0ab3fe38bc6b6058b704aa59a1"
   integrity sha512-2FWYlkphQ/83MG7b9qqBJfJJ0K9zupNz/6n4EdDuNLw6hQHGp4Sp4UMDRyBvA/xCTYDBaPSuSjHuu45tSujegg==
 
+"@11ty/eleventy-cache-assets@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@11ty/eleventy-cache-assets/-/eleventy-cache-assets-2.0.4.tgz#8a4da7b61c0933566877cda8db9a47d6c594c78e"
+  integrity sha512-EP3QYeHo3yfKF92R5Mh9MaLLgZjZNxWM8c0BwLNUCeZpOOA4Ry9HOs8k+6pNQ0wletUvMSnuzIa1hMiC67OcGw==
+  dependencies:
+    debug "^4.3.1"
+    flat-cache "^3.0.4"
+    node-fetch "^2.6.1"
+    p-queue "^6.6.2"
+    short-hash "^1.0.0"
+
+"@11ty/eleventy-img@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@11ty/eleventy-img/-/eleventy-img-0.7.3.tgz#d40feedbb57a5f02a51c76192bfc8baf7c9f66bb"
+  integrity sha512-JwP+v6CRfUFH5zfB7055iQceVfv6YKjQGVzTFPGPEcKtaq5IOrakKc5lJH3G5WPgJjKnqfwuSFqS2be5y97Mxw==
+  dependencies:
+    "@11ty/eleventy-cache-assets" "^2.0.4"
+    debug "^4.3.1"
+    fs-extra "^9.0.1"
+    image-size "^0.9.3"
+    p-queue "^6.6.2"
+    sharp "^0.27.0"
+    short-hash "^1.0.0"
+
 "@11ty/eleventy-plugin-rss@^1.0.9":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.0.9.tgz#bc46085918e788a72a517b79c60d425fe0c78831"
@@ -1880,7 +1904,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -2827,6 +2851,19 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
+flatted@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
+  integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -3241,6 +3278,11 @@ has@^1.0.0, has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hash-string/-/hash-string-1.0.0.tgz#c3fa15f078ddd16bc150b4176fde7091620f2c7f"
+  integrity sha1-w/oV8Hjd0WvBULQXb95wkWIPLH8=
+
 hasha@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.2.tgz#a48477989b3b327aea3c04f53096d816d97522a1"
@@ -3457,6 +3499,13 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+image-size@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.9.3.tgz#f7efce6b0a1649b44b9bc43b9d9a5acf272264b6"
+  integrity sha512-5SakFa79uhUVSjKeQE30GVzzLJ0QNzB53+I+/VD1vIesD6GP6uatWIlgU0uisFNLt1u0d6kBydp7yfk+lLJhLQ==
+  dependencies:
+    queue "6.0.1"
 
 imageinfo@^1.0.4:
   version "1.0.4"
@@ -4726,6 +4775,11 @@ node-emoji@^1.8.1:
   dependencies:
     lodash.toarray "^4.4.0"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-releases@^1.1.67:
   version "1.1.67"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
@@ -5009,7 +5063,7 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-queue@^6.2.1, p-queue@^6.6.1:
+p-queue@^6.2.1, p-queue@^6.6.1, p-queue@^6.6.2:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
   integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
@@ -6078,6 +6132,13 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+queue@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.1.tgz#abd5a5b0376912f070a25729e0b6a7d565683791"
+  integrity sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==
+  dependencies:
+    inherits "~2.0.3"
+
 quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
@@ -6668,6 +6729,13 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+short-hash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/short-hash/-/short-hash-1.0.0.tgz#3f491d728fcc777ec605bbaf7f83f23712f42050"
+  integrity sha1-P0kdco/Md37GBbuvf4PyNxL0IFA=
+  dependencies:
+    hash-string "^1.0.0"
 
 sift@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
I learned a lot about `sharp` and srcsets and the like, by doing this by hand. But, there were some memory usage issues and this eleventy plugin is back in action with a bunch of good updates (AVIF support), and it seems to be working nicely after some of those updates. Also, the new `generateHTML` method is pretty nice.

I kept my `skipOptimization` part on the original script, so we use original images in DEV to save battery and CPU cycles on our puny machines.