### PR TITLE
Use figcaptions for images

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,13 +2,15 @@ require("dotenv").config();
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 const eleventyHelmetPlugin = require("eleventy-plugin-helmet");
 const markdownIt = require("markdown-it");
-const mdImplicitFigures = require("markdown-it-implicit-figures");
+const mdFigures = require("markdown-it-image-figures");
 const mdPrism = require("markdown-it-prism");
 const htmlmin = require("html-minifier");
 const markdownItAttrs = require("markdown-it-attrs");
 const markdownItRenderer = new markdownIt({ html: true })
   .use(markdownItAttrs)
-  .use(mdImplicitFigures)
+  .use(mdFigures, {
+    figcaption: true,
+  })
   .use(mdPrism);
 const image = require("./utils/image");
 

--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -4,3 +4,9 @@
 body.no-js .lazy {
   display: none !important;
 }
+
+.prose figcaption {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@hotwired/turbo": "^7.0.1",
     "instant.page": "^5.1.0",
     "markdown-it-attrs": "^4.1.0",
+    "markdown-it-image-figures": "^2.0.0",
     "vanilla-lazyload": "^17.5.0"
   },
   "devDependencies": {
@@ -31,7 +32,6 @@
     "graphql-request": "^3.6.1",
     "hasha": "^5.2.2",
     "html-minifier": "^4.0.0",
-    "markdown-it-implicit-figures": "^0.10.0",
     "markdown-it-prism": "^2.2.1",
     "netlify-plugin-cache": "^1.0.3",
     "postcss": "^8.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,6 +2989,13 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-xml-parser@^3.19.0:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz#152a1d51d445380f7046b304672dd55d15c9e736"
+  integrity sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==
+  dependencies:
+    strnum "^1.0.4"
+
 fastq@^1.6.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.1.tgz#5d8175aae17db61947f8b162cfc7f63264d22807"
@@ -4111,6 +4118,13 @@ is-string@^1.0.5, is-string@^1.0.6:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
   integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
 
+is-svg@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.2.tgz#a119e9932e1af53f6be1969d1790d6cc5fd947d3"
+  integrity sha512-mM90duy00JGMyjqIVHu9gNTjywdZV+8qNasX8cm/EEYZ53PHDgajvbBwNVvty5dwSAxLUD3p3bdo+7sR/UMrpw==
+  dependencies:
+    fast-xml-parser "^3.19.0"
+
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
@@ -4656,10 +4670,12 @@ markdown-it-attrs@^4.1.0:
   resolved "https://registry.yarnpkg.com/markdown-it-attrs/-/markdown-it-attrs-4.1.0.tgz#e27f023cd8731b15b4a5e971d51e6f45b3b947bc"
   integrity sha512-xd1SuNQPArGYl3SN1bsOHRnmMenkqeLDbTR0udeyGMSFBnaOtxP4yz1SEKrjsV/XYFygFAeKFHgbbj6AwxbTfA==
 
-markdown-it-implicit-figures@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-implicit-figures/-/markdown-it-implicit-figures-0.10.0.tgz#0e75e80b846da1e3117a3fc6d6b013d0cc3f2a8c"
-  integrity sha512-1TWr6+apyoJvRa4Z7eIolZdeajZCRBcc1ckVXon7XwdL8MfydIWsHnZOS5zRrpUNX5b0/O9giWcmuItSkleK5A==
+markdown-it-image-figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-image-figures/-/markdown-it-image-figures-2.0.0.tgz#52434a9b3b23d1c1f6bb5f8de688070ad1d3148c"
+  integrity sha512-gZDwvQ+SDA2KYwoEbs42BRDv57j2HEe7a1fUO8aKO6ku1GIvu5nBbxoJ7eBUTZOQYOQ0J78ZaZn0sdflEMjzXw==
+  dependencies:
+    is-svg "^4.3.1"
 
 markdown-it-prism@^2.2.1:
   version "2.2.1"
@@ -7621,6 +7637,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strnum@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Use `markdown-it-image-figures` to implement figcaptions for images. Check https://www.npmjs.com/package/markdown-it-image-figures/v/1.0.1 for usage tips.

Example: 
![image](https://user-images.githubusercontent.com/9119466/146382280-3cd05299-f9cc-44ae-9bd7-45b04cba3942.png)
